### PR TITLE
feat: add optional agents.workspace.json integration to SessionStart hook

### DIFF
--- a/bin/gsd-tools.cjs
+++ b/bin/gsd-tools.cjs
@@ -1234,11 +1234,16 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
             if (workspaceJson) {
               let maxFiles = DEFAULT_MAX_FILES;
               try {
-                const cfgPath = path.join(planningPaths(cwd).planning, 'config.json');
+                const { planningPaths: _pp } = require('./lib/core.cjs');
+                const cfgPath = path.join(_pp(cwd).planning, 'config.json');
                 const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
                 const raw = cfg && cfg[MAX_FILES_CONFIG_KEY];
                 if (typeof raw === 'number' && raw >= 0) maxFiles = raw;
-              } catch { /* absent or unreadable config — use default */ }
+              } catch (cfgErr) {
+                if (cfgErr && cfgErr.code !== 'ENOENT') {
+                  process.stderr.write(`GSD: workspace.json config read failed (${cfgErr.code || cfgErr.message}). Using default.\n`);
+                }
+              }
               const contextString = buildContextString(workspaceJson, { maxFiles });
               if (contextString) {
                 process.stdout.write('\n\n' + contextString);

--- a/bin/gsd-tools.cjs
+++ b/bin/gsd-tools.cjs
@@ -1226,6 +1226,22 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
               process.stderr.write('GSD: session checkpoint detected, auto-resuming...\n');
             }
           } catch { /* never break session start */ }
+
+          // workspace.json read — fail-soft, zero impact if absent
+          try {
+            const { readWorkspaceJson, buildContextString, MAX_FILES_CONFIG_KEY, DEFAULT_MAX_FILES } = require('./lib/workspace-json.cjs');
+            const workspaceJson = readWorkspaceJson(cwd);
+            if (workspaceJson) {
+              let config = null;
+              try { config = require('./lib/config.cjs').loadConfig(cwd); } catch { /* config optional */ }
+              const maxFiles = (config && config[MAX_FILES_CONFIG_KEY]) || DEFAULT_MAX_FILES;
+              const contextString = buildContextString(workspaceJson, { maxFiles });
+              if (contextString) {
+                process.stdout.write(contextString);
+                process.stderr.write('GSD: workspace.json intelligence injected.\n');
+              }
+            }
+          } catch { /* never break session start */ }
         }
       } else if (hookType === 'pre-compact') {
         try {

--- a/bin/gsd-tools.cjs
+++ b/bin/gsd-tools.cjs
@@ -1232,9 +1232,13 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
             const { readWorkspaceJson, buildContextString, MAX_FILES_CONFIG_KEY, DEFAULT_MAX_FILES } = require('./lib/workspace-json.cjs');
             const workspaceJson = readWorkspaceJson(cwd);
             if (workspaceJson) {
-              let config = null;
-              try { config = require('./lib/config.cjs').loadConfig(cwd); } catch { /* config optional */ }
-              const maxFiles = (config && config[MAX_FILES_CONFIG_KEY]) || DEFAULT_MAX_FILES;
+              let maxFiles = DEFAULT_MAX_FILES;
+              try {
+                const cfgPath = path.join(planningPaths(cwd).planning, 'config.json');
+                const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+                const raw = cfg && cfg[MAX_FILES_CONFIG_KEY];
+                if (typeof raw === 'number' && raw >= 0) maxFiles = raw;
+              } catch { /* absent or unreadable config — use default */ }
               const contextString = buildContextString(workspaceJson, { maxFiles });
               if (contextString) {
                 process.stdout.write('\n\n' + contextString);

--- a/bin/gsd-tools.cjs
+++ b/bin/gsd-tools.cjs
@@ -1237,11 +1237,13 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
               const maxFiles = (config && config[MAX_FILES_CONFIG_KEY]) || DEFAULT_MAX_FILES;
               const contextString = buildContextString(workspaceJson, { maxFiles });
               if (contextString) {
-                process.stdout.write(contextString);
+                process.stdout.write('\n\n' + contextString);
                 process.stderr.write('GSD: workspace.json intelligence injected.\n');
               }
             }
-          } catch { /* never break session start */ }
+          } catch (err) {
+            process.stderr.write('GSD: workspace.json block failed: ' + (err && err.message ? err.message : String(err)) + '\n');
+          }
         }
       } else if (hookType === 'pre-compact') {
         try {

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -13,6 +13,12 @@ const MAX_FILES_CONFIG_KEY = 'gsd.workspace_json_max_files';
 
 const SUPPORTED_VERSIONS = ['0.1', '1.0'];
 
+// DoS guards — cap input sizes before materialising arrays in memory.
+const MAX_INDEX_ENTRIES = 10000;
+const MAX_MANIFEST_ENTRIES = 100;
+const MAX_FRAGILE_FILES = 500;
+const MAX_CO_CHANGE_PATTERNS = 200;
+
 // Returns null if absent, malformed, or unreadable — never throws.
 function readWorkspaceJson(cwd) {
   for (const segments of [CANONICAL_PATH, LEGACY_PATH]) {
@@ -61,6 +67,8 @@ function readWorkspaceJson(cwd) {
 function buildContextString(workspaceJson, options) {
   if (!workspaceJson) return '';
 
+  const { sanitizeForPrompt } = require('./security.cjs');
+
   const rawMax = options && options.maxFiles;
   const maxFiles = (typeof rawMax === 'number' && rawMax >= 0) ? rawMax : DEFAULT_MAX_FILES;
   const sections = [];
@@ -71,8 +79,13 @@ function buildContextString(workspaceJson, options) {
 
     if (Array.isArray(generated.frameworkManifest)) {
       const frameworks = generated.frameworkManifest
+        .slice(0, MAX_MANIFEST_ENTRIES)
         .filter(f => f && typeof f.name === 'string' && (f.confidence == null || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD))
-        .map(f => `${f.name}@${typeof f.version === 'string' ? f.version : 'unknown'}`)
+        .map(f => {
+          const name = sanitizeForPrompt(f.name);
+          const version = typeof f.version === 'string' ? sanitizeForPrompt(f.version) : 'unknown';
+          return `${name}@${version}`;
+        })
         .join(', ');
       if (frameworks) {
         parts.push(`Detected stack: ${frameworks}.`);
@@ -80,7 +93,12 @@ function buildContextString(workspaceJson, options) {
     }
 
     if (generated.fileIndex && typeof generated.fileIndex === 'object' && !Array.isArray(generated.fileIndex)) {
-      const fragileFromIndex = Object.entries(generated.fileIndex)
+      const allEntries = Object.entries(generated.fileIndex);
+      if (allEntries.length > MAX_INDEX_ENTRIES) {
+        process.stderr.write(`GSD: workspace.json fileIndex has ${allEntries.length} entries; processing first ${MAX_INDEX_ENTRIES}.\n`);
+      }
+      const fragileFromIndex = allEntries
+        .slice(0, MAX_INDEX_ENTRIES)
         .filter(([, data]) => data && typeof data.fragility === 'number' && data.fragility >= FRAGILITY_THRESHOLD)
         .sort((a, b) => b[1].fragility - a[1].fragility)
         .slice(0, maxFiles);
@@ -91,7 +109,7 @@ function buildContextString(workspaceJson, options) {
             const score = data.fragility.toFixed(2);
             const aiCount = data.aiModificationCount || 0;
             const humanCount = data.humanModificationCount || 0;
-            return `${file} (fragility ${score}, ${aiCount} AI / ${humanCount} human modifications)`;
+            return `${sanitizeForPrompt(file)} (fragility ${score}, ${aiCount} AI / ${humanCount} human modifications)`;
           })
           .join('; ');
         parts.push(`Empirically fragile files: ${list}.`);
@@ -106,9 +124,10 @@ function buildContextString(workspaceJson, options) {
   const manual = workspaceJson.manual;
   if (manual && typeof manual === 'object' && Array.isArray(manual.fragileFiles) && manual.fragileFiles.length > 0) {
     const list = manual.fragileFiles
+      .slice(0, MAX_FRAGILE_FILES)
       .map(f => {
         if (f && typeof f === 'object' && typeof f.path === 'string' && typeof f.reason === 'string') {
-          return `${f.path} (${f.reason})`;
+          return `${sanitizeForPrompt(f.path)} (${sanitizeForPrompt(f.reason)})`;
         }
         return null;
       })
@@ -121,12 +140,14 @@ function buildContextString(workspaceJson, options) {
 
   if (manual && typeof manual === 'object' && Array.isArray(manual.coChangePatterns) && manual.coChangePatterns.length > 0) {
     const list = manual.coChangePatterns
+      .slice(0, MAX_CO_CHANGE_PATTERNS)
       .map(p => {
         if (!p || !Array.isArray(p.files)) return null;
-        const stringFiles = p.files.filter(x => typeof x === 'string');
+        const stringFiles = p.files.filter(x => typeof x === 'string').map(x => sanitizeForPrompt(x));
         if (stringFiles.length === 0) return null;
         const filesPart = stringFiles.join(' ↔ ');
-        return (typeof p.note === 'string' && p.note) ? `${filesPart} (${p.note})` : filesPart;
+        const note = typeof p.note === 'string' && p.note ? sanitizeForPrompt(p.note) : null;
+        return note ? `${filesPart} (${note})` : filesPart;
       })
       .filter(Boolean)
       .join('; ');

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -13,12 +13,7 @@ const MAX_FILES_CONFIG_KEY = 'gsd.workspace_json_max_files';
 
 const SUPPORTED_VERSIONS = ['0.1', '1.0'];
 
-/**
- * Reads agents.workspace.json from the given cwd if present.
- * Searches canonical path first (.agents/agents.workspace.json),
- * then legacy fallback (agents.workspace.json at repo root).
- * Returns null if absent, malformed, or unreadable — never throws.
- */
+// Returns null if absent, malformed, or unreadable — never throws.
 function readWorkspaceJson(cwd) {
   const canonicalFilePath = path.join(cwd, ...CANONICAL_PATH);
   const legacyFilePath = path.join(cwd, ...LEGACY_PATH);
@@ -38,10 +33,9 @@ function readWorkspaceJson(cwd) {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw);
 
-    const version = parsed.version;
-    if (version && !SUPPORTED_VERSIONS.some(v => String(version).startsWith(v))) {
+    if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version).startsWith(v))) {
       process.stderr.write(
-        `GSD: workspace.json version ${version} is newer than supported. ` +
+        `GSD: workspace.json version ${parsed.version} is newer than supported. ` +
         `Reading what we can. Consider upgrading gsd-plugin.\n`
       );
     }
@@ -55,18 +49,11 @@ function readWorkspaceJson(cwd) {
   }
 }
 
-/**
- * Builds the injected context string from workspace.json data.
- * Returns empty string if no relevant data is present.
- *
- * Scoped to: generated section (entire), manual.fragileFiles,
- * manual.coChangePatterns — per issue #5 agreement.
- */
+// Scoped to generated + manual.fragileFiles + manual.coChangePatterns per issue #5.
 function buildContextString(workspaceJson, options) {
   if (!workspaceJson) return '';
 
-  const opts = options || {};
-  const maxFiles = opts.maxFiles || DEFAULT_MAX_FILES;
+  const maxFiles = (options && options.maxFiles) || DEFAULT_MAX_FILES;
   const sections = [];
 
   const generated = workspaceJson.generated;

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -11,7 +11,7 @@ const FRAMEWORK_CONFIDENCE_THRESHOLD = 0.7;
 const DEFAULT_MAX_FILES = 5;
 const MAX_FILES_CONFIG_KEY = 'gsd.workspace_json_max_files';
 
-const SUPPORTED_VERSIONS = ['0.1', '1.0'];
+const SUPPORTED_VERSIONS = ['0.1'];
 
 // DoS guards — cap input sizes before materialising arrays in memory.
 const MAX_INDEX_ENTRIES = 10000;

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -15,76 +15,74 @@ const SUPPORTED_VERSIONS = ['0.1', '1.0'];
 
 // Returns null if absent, malformed, or unreadable — never throws.
 function readWorkspaceJson(cwd) {
-  const canonicalFilePath = path.join(cwd, ...CANONICAL_PATH);
-  const legacyFilePath = path.join(cwd, ...LEGACY_PATH);
-
-  let filePath = null;
-  if (fs.existsSync(canonicalFilePath)) {
-    filePath = canonicalFilePath;
-  } else if (fs.existsSync(legacyFilePath)) {
-    filePath = legacyFilePath;
-  }
-
-  if (!filePath) {
-    return null;
-  }
-
-  try {
-    const raw = fs.readFileSync(filePath, 'utf-8');
-    const parsed = JSON.parse(raw);
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      process.stderr.write('GSD: workspace.json is not a JSON object. Skipping.\n');
+  for (const segments of [CANONICAL_PATH, LEGACY_PATH]) {
+    const filePath = path.join(cwd, ...segments);
+    let raw;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch (e) {
+      if (e.code === 'ENOENT') continue;
+      process.stderr.write(`GSD: workspace.json at ${filePath} could not be read (${e.code || e.message}). Skipping.\n`);
       return null;
     }
 
-    if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version) === v)) {
-      process.stderr.write(
-        `GSD: workspace.json version ${parsed.version} is newer than supported. ` +
-        `Reading what we can. Consider upgrading gsd-plugin.\n`
-      );
-    }
+    try {
+      const parsed = JSON.parse(raw);
 
-    return parsed;
-  } catch (err) {
-    process.stderr.write(
-      `GSD: workspace.json present but unreadable. Skipping. (${err.message})\n`
-    );
-    return null;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        process.stderr.write('GSD: workspace.json is not a JSON object. Skipping.\n');
+        return null;
+      }
+
+      if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version) === v)) {
+        process.stderr.write(
+          `GSD: workspace.json version ${String(parsed.version)} is newer than supported. ` +
+          `Reading what we can. Consider upgrading gsd-plugin.\n`
+        );
+      }
+
+      return parsed;
+    } catch (err) {
+      process.stderr.write(`GSD: workspace.json at ${filePath} is not valid JSON. Skipping. (${err.message})\n`);
+      return null;
+    }
   }
+
+  return null;
 }
 
 // Scoped to generated + manual.fragileFiles + manual.coChangePatterns per issue #5.
 function buildContextString(workspaceJson, options) {
   if (!workspaceJson) return '';
 
-  const maxFiles = (options && options.maxFiles) || DEFAULT_MAX_FILES;
+  const rawMax = options && options.maxFiles;
+  const maxFiles = (typeof rawMax === 'number' && rawMax >= 0) ? rawMax : DEFAULT_MAX_FILES;
   const sections = [];
 
   const generated = workspaceJson.generated;
-  if (generated) {
+  if (generated && typeof generated === 'object') {
     const parts = [];
 
-    if (generated.frameworkManifest && Array.isArray(generated.frameworkManifest)) {
+    if (Array.isArray(generated.frameworkManifest)) {
       const frameworks = generated.frameworkManifest
-        .filter(f => f && typeof f.name === 'string' && (f.confidence === undefined || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD))
-        .map(f => `${f.name}@${f.version || 'unknown'}`)
+        .filter(f => f && typeof f.name === 'string' && (f.confidence == null || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD))
+        .map(f => `${f.name}@${typeof f.version === 'string' ? f.version : 'unknown'}`)
         .join(', ');
       if (frameworks) {
         parts.push(`Detected stack: ${frameworks}.`);
       }
     }
 
-    if (generated.fileIndex && typeof generated.fileIndex === 'object') {
+    if (generated.fileIndex && typeof generated.fileIndex === 'object' && !Array.isArray(generated.fileIndex)) {
       const fragileFromIndex = Object.entries(generated.fileIndex)
         .filter(([, data]) => data && typeof data.fragility === 'number' && data.fragility >= FRAGILITY_THRESHOLD)
-        .sort((a, b) => (b[1].fragility || 0) - (a[1].fragility || 0))
+        .sort((a, b) => b[1].fragility - a[1].fragility)
         .slice(0, maxFiles);
 
       if (fragileFromIndex.length > 0) {
         const list = fragileFromIndex
           .map(([file, data]) => {
-            const score = (data.fragility || 0).toFixed(2);
+            const score = data.fragility.toFixed(2);
             const aiCount = data.aiModificationCount || 0;
             const humanCount = data.humanModificationCount || 0;
             return `${file} (fragility ${score}, ${aiCount} AI / ${humanCount} human modifications)`;
@@ -100,10 +98,10 @@ function buildContextString(workspaceJson, options) {
   }
 
   const manual = workspaceJson.manual;
-  if (manual && Array.isArray(manual.fragileFiles) && manual.fragileFiles.length > 0) {
+  if (manual && typeof manual === 'object' && Array.isArray(manual.fragileFiles) && manual.fragileFiles.length > 0) {
     const list = manual.fragileFiles
       .map(f => {
-        if (f && typeof f === 'object' && f.path && f.reason) {
+        if (f && typeof f === 'object' && typeof f.path === 'string' && typeof f.reason === 'string') {
           return `${f.path} (${f.reason})`;
         }
         return null;
@@ -115,14 +113,14 @@ function buildContextString(workspaceJson, options) {
     }
   }
 
-  if (manual && Array.isArray(manual.coChangePatterns) && manual.coChangePatterns.length > 0) {
+  if (manual && typeof manual === 'object' && Array.isArray(manual.coChangePatterns) && manual.coChangePatterns.length > 0) {
     const list = manual.coChangePatterns
       .map(p => {
-        if (p && Array.isArray(p.files) && p.files.length > 0) {
-          const filesPart = p.files.join(' ↔ ');
-          return p.note ? `${filesPart} (${p.note})` : filesPart;
-        }
-        return null;
+        if (!p || !Array.isArray(p.files)) return null;
+        const stringFiles = p.files.filter(x => typeof x === 'string');
+        if (stringFiles.length === 0) return null;
+        const filesPart = stringFiles.join(' ↔ ');
+        return (typeof p.note === 'string' && p.note) ? `${filesPart} (${p.note})` : filesPart;
       })
       .filter(Boolean)
       .join('; ');

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -1,0 +1,159 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const CANONICAL_PATH = ['.agents', 'agents.workspace.json'];
+const LEGACY_PATH = ['agents.workspace.json'];
+
+const FRAGILITY_THRESHOLD = 0.7;
+const FRAMEWORK_CONFIDENCE_THRESHOLD = 0.7;
+const DEFAULT_MAX_FILES = 5;
+const MAX_FILES_CONFIG_KEY = 'gsd.workspace_json_max_files';
+
+const SUPPORTED_VERSIONS = ['0.1', '1.0'];
+
+/**
+ * Reads agents.workspace.json from the given cwd if present.
+ * Searches canonical path first (.agents/agents.workspace.json),
+ * then legacy fallback (agents.workspace.json at repo root).
+ * Returns null if absent, malformed, or unreadable — never throws.
+ */
+function readWorkspaceJson(cwd) {
+  const canonicalFilePath = path.join(cwd, ...CANONICAL_PATH);
+  const legacyFilePath = path.join(cwd, ...LEGACY_PATH);
+
+  let filePath = null;
+  if (fs.existsSync(canonicalFilePath)) {
+    filePath = canonicalFilePath;
+  } else if (fs.existsSync(legacyFilePath)) {
+    filePath = legacyFilePath;
+  }
+
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+
+    const version = parsed.version;
+    if (version && !SUPPORTED_VERSIONS.some(v => String(version).startsWith(v))) {
+      process.stderr.write(
+        `GSD: workspace.json version ${version} is newer than supported. ` +
+        `Reading what we can. Consider upgrading gsd-plugin.\n`
+      );
+    }
+
+    return parsed;
+  } catch (err) {
+    process.stderr.write(
+      `GSD: workspace.json present but unreadable. Skipping. (${err.message})\n`
+    );
+    return null;
+  }
+}
+
+/**
+ * Builds the injected context string from workspace.json data.
+ * Returns empty string if no relevant data is present.
+ *
+ * Scoped to: generated section (entire), manual.fragileFiles,
+ * manual.coChangePatterns — per issue #5 agreement.
+ */
+function buildContextString(workspaceJson, options) {
+  if (!workspaceJson) return '';
+
+  const opts = options || {};
+  const maxFiles = opts.maxFiles || DEFAULT_MAX_FILES;
+  const sections = [];
+
+  const generated = workspaceJson.generated;
+  if (generated) {
+    const parts = [];
+
+    if (generated.frameworkManifest && Array.isArray(generated.frameworkManifest)) {
+      const frameworks = generated.frameworkManifest
+        .filter(f => f.confidence === undefined || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD)
+        .map(f => `${f.name}@${f.version || 'unknown'}`)
+        .join(', ');
+      if (frameworks) {
+        parts.push(`Detected stack: ${frameworks}.`);
+      }
+    }
+
+    if (generated.fileIndex && typeof generated.fileIndex === 'object') {
+      const fragileFromIndex = Object.entries(generated.fileIndex)
+        .filter(([, data]) => data && data.fragility !== undefined && data.fragility >= FRAGILITY_THRESHOLD)
+        .sort((a, b) => (b[1].fragility || 0) - (a[1].fragility || 0))
+        .slice(0, maxFiles);
+
+      if (fragileFromIndex.length > 0) {
+        const list = fragileFromIndex
+          .map(([file, data]) => {
+            const score = (data.fragility || 0).toFixed(2);
+            const aiCount = data.aiModificationCount || 0;
+            const humanCount = data.humanModificationCount || 0;
+            return `${file} (fragility ${score}, ${aiCount} AI / ${humanCount} human modifications)`;
+          })
+          .join('; ');
+        parts.push(`Empirically fragile files: ${list}.`);
+      }
+    }
+
+    if (parts.length > 0) {
+      sections.push(parts.join(' '));
+    }
+  }
+
+  const manual = workspaceJson.manual;
+  if (manual && Array.isArray(manual.fragileFiles) && manual.fragileFiles.length > 0) {
+    const list = manual.fragileFiles
+      .map(f => {
+        if (f && typeof f === 'object' && f.path && f.reason) {
+          return `${f.path} (${f.reason})`;
+        }
+        return null;
+      })
+      .filter(Boolean)
+      .join('; ');
+    if (list) {
+      sections.push(`Human-flagged fragile files: ${list}.`);
+    }
+  }
+
+  if (manual && Array.isArray(manual.coChangePatterns) && manual.coChangePatterns.length > 0) {
+    const list = manual.coChangePatterns
+      .map(p => {
+        if (p && Array.isArray(p.files) && p.files.length > 0) {
+          const filesPart = p.files.join(' ↔ ');
+          return p.note ? `${filesPart} (${p.note})` : filesPart;
+        }
+        return null;
+      })
+      .filter(Boolean)
+      .join('; ');
+    if (list) {
+      sections.push(`Files that historically change together: ${list}.`);
+    }
+  }
+
+  if (sections.length === 0) return '';
+
+  return [
+    'Codebase intelligence (workspace.json):',
+    sections.join(' '),
+    'Treat fragile files with extra care; historical regression rate is elevated.'
+  ].join(' ');
+}
+
+module.exports = {
+  readWorkspaceJson,
+  buildContextString,
+  CANONICAL_PATH,
+  LEGACY_PATH,
+  FRAGILITY_THRESHOLD,
+  DEFAULT_MAX_FILES,
+  MAX_FILES_CONFIG_KEY,
+};

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -34,11 +34,17 @@ function readWorkspaceJson(cwd) {
         return null;
       }
 
-      if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version) === v)) {
-        process.stderr.write(
-          `GSD: workspace.json version ${String(parsed.version)} is newer than supported. ` +
-          `Reading what we can. Consider upgrading gsd-plugin.\n`
-        );
+      if (parsed.version) {
+        const fileMajor = String(parsed.version).split('.')[0];
+        const supportedMajors = SUPPORTED_VERSIONS.map(v => v.split('.')[0]);
+        if (!supportedMajors.includes(fileMajor)) {
+          process.stderr.write(
+            `GSD: workspace.json requires version ${String(parsed.version)} ` +
+            `but this plugin supports ${SUPPORTED_VERSIONS.join(', ')}. ` +
+            `Update gsd-plugin or regenerate your workspace.json.\n`
+          );
+          return null;
+        }
       }
 
       return parsed;

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -33,7 +33,12 @@ function readWorkspaceJson(cwd) {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw);
 
-    if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version).startsWith(v))) {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      process.stderr.write('GSD: workspace.json is not a JSON object. Skipping.\n');
+      return null;
+    }
+
+    if (parsed.version && !SUPPORTED_VERSIONS.some(v => String(parsed.version) === v)) {
       process.stderr.write(
         `GSD: workspace.json version ${parsed.version} is newer than supported. ` +
         `Reading what we can. Consider upgrading gsd-plugin.\n`
@@ -62,7 +67,7 @@ function buildContextString(workspaceJson, options) {
 
     if (generated.frameworkManifest && Array.isArray(generated.frameworkManifest)) {
       const frameworks = generated.frameworkManifest
-        .filter(f => f.confidence === undefined || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD)
+        .filter(f => f && typeof f.name === 'string' && (f.confidence === undefined || f.confidence >= FRAMEWORK_CONFIDENCE_THRESHOLD))
         .map(f => `${f.name}@${f.version || 'unknown'}`)
         .join(', ');
       if (frameworks) {
@@ -72,7 +77,7 @@ function buildContextString(workspaceJson, options) {
 
     if (generated.fileIndex && typeof generated.fileIndex === 'object') {
       const fragileFromIndex = Object.entries(generated.fileIndex)
-        .filter(([, data]) => data && data.fragility !== undefined && data.fragility >= FRAGILITY_THRESHOLD)
+        .filter(([, data]) => data && typeof data.fragility === 'number' && data.fragility >= FRAGILITY_THRESHOLD)
         .sort((a, b) => (b[1].fragility || 0) - (a[1].fragility || 0))
         .slice(0, maxFiles);
 

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -13,6 +13,19 @@ function makeTempRepo() {
   return dir;
 }
 
+// Always cleans up dir even when the test body throws.
+function withTempRepo(fn, opts) {
+  const legacy = opts && opts.legacy;
+  const dir = legacy
+    ? fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-workspace-legacy-'))
+    : makeTempRepo();
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function writeCanonicalWorkspaceJson(dir, content) {
   fs.writeFileSync(
     path.join(dir, '.agents', 'agents.workspace.json'),
@@ -49,29 +62,24 @@ function check(name, fn) {
 }
 
 // Test 1: absent file produces zero workspace.json output
-check('absent file produces no workspace.json injection', () => {
-  const dir = makeTempRepo();
+check('absent file produces no workspace.json injection', () => withTempRepo(dir => {
   const result = runHook(dir);
   if (result.stdout.includes('workspace.json')) {
     throw new Error('Hook injected workspace.json context when file was absent');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 2: malformed file fails soft
-check('malformed file does not crash hook', () => {
-  const dir = makeTempRepo();
+check('malformed file does not crash hook', () => withTempRepo(dir => {
   fs.writeFileSync(path.join(dir, '.agents', 'agents.workspace.json'), '{not valid json');
   const result = runHook(dir);
   if (result.status !== 0) {
     throw new Error(`Hook exited with status ${result.status} on malformed file`);
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 3: valid canonical-path file injects expected fragile files
-check('canonical-path file injects fragility intelligence', () => {
-  const dir = makeTempRepo();
+check('canonical-path file injects fragility intelligence', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     generated: {
@@ -92,12 +100,10 @@ check('canonical-path file injects fragility intelligence', () => {
   if (!result.stdout.includes('0.91')) {
     throw new Error('Hook did not inject fragility score');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 4: legacy-path file is also read
-check('legacy-path file is read when canonical absent', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-workspace-legacy-'));
+check('legacy-path file is read when canonical absent', () => withTempRepo(dir => {
   writeLegacyWorkspaceJson(dir, {
     version: '1.0',
     generated: {
@@ -115,12 +121,10 @@ check('legacy-path file is read when canonical absent', () => {
   if (!result.stdout.includes('src/legacy.ts')) {
     throw new Error('Legacy-path workspace.json was not read');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}, { legacy: true }));
 
 // Test 5: canonical wins when both present
-check('canonical path wins when both present', () => {
-  const dir = makeTempRepo();
+check('canonical path wins when both present', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     generated: {
@@ -146,12 +150,10 @@ check('canonical path wins when both present', () => {
   if (result.stdout.includes('src/legacy.ts')) {
     throw new Error('Legacy file should not be read when canonical exists');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 6: framework manifest with low confidence is filtered
-check('framework manifest filters low-confidence entries', () => {
-  const dir = makeTempRepo();
+check('framework manifest filters low-confidence entries', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     generated: {
@@ -169,12 +171,10 @@ check('framework manifest filters low-confidence entries', () => {
   if (result.stdout.includes('unknown-framework')) {
     throw new Error('Low-confidence framework should have been filtered');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 7: fragility threshold of 0.7 is enforced (per spec section 3.5)
-check('files below 0.7 fragility threshold are not injected', () => {
-  const dir = makeTempRepo();
+check('files below 0.7 fragility threshold are not injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     generated: {
@@ -192,12 +192,10 @@ check('files below 0.7 fragility threshold are not injected', () => {
   if (result.stdout.includes('src/low.ts')) {
     throw new Error('Below-threshold file should have been filtered per spec section 3.5');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 8: manual.fragileFiles injection works (spec shape: { path, reason })
-check('manual.fragileFiles are injected', () => {
-  const dir = makeTempRepo();
+check('manual.fragileFiles are injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     manual: {
@@ -213,12 +211,10 @@ check('manual.fragileFiles are injected', () => {
   if (!result.stdout.includes('Single point of failure')) {
     throw new Error('Manual fragile file reason not injected');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 9: coChangePatterns are injected (spec shape: { files, note })
-check('coChangePatterns are injected', () => {
-  const dir = makeTempRepo();
+check('coChangePatterns are injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     manual: {
@@ -237,12 +233,10 @@ check('coChangePatterns are injected', () => {
   if (!result.stdout.includes('Schema changes')) {
     throw new Error('coChangePattern note not injected');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 10: HANDOFF.json read is unaffected by workspace.json presence
-check('HANDOFF.json injection still works alongside workspace.json', () => {
-  const dir = makeTempRepo();
+check('HANDOFF.json injection still works alongside workspace.json', () => withTempRepo(dir => {
   fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
   fs.writeFileSync(
     path.join(dir, '.planning', 'HANDOFF.json'),
@@ -260,12 +254,10 @@ check('HANDOFF.json injection still works alongside workspace.json', () => {
   if (!result.stdout.includes('Phase 4')) {
     throw new Error('HANDOFF.json injection regressed');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 11: DEFAULT_MAX_FILES cap enforced — 8 files above threshold, only 5 in output
-check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => {
-  const dir = makeTempRepo();
+check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => withTempRepo(dir => {
   const fileIndex = {};
   for (let i = 1; i <= 8; i++) {
     fileIndex[`src/file${i}.ts`] = {
@@ -286,12 +278,10 @@ check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => {
   if (injectedCount !== 5) {
     throw new Error(`Expected 5 files injected (DEFAULT_MAX_FILES), got ${injectedCount}`);
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Test 12: mixed manual.fragileFiles — valid entries inject, invalid entries are skipped
-check('mixed manual.fragileFiles skips invalid entries without crashing', () => {
-  const dir = makeTempRepo();
+check('mixed manual.fragileFiles skips invalid entries without crashing', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',
     manual: {
@@ -314,8 +304,7 @@ check('mixed manual.fragileFiles skips invalid entries without crashing', () => 
   if (result.stdout.includes('bare string entry') || result.stdout.includes('missing-reason') || result.stdout.includes('missing path')) {
     throw new Error('Invalid fragileFiles entry leaked into output');
   }
-  fs.rmSync(dir, { recursive: true, force: true });
-});
+}));
 
 // Report
 let failures = 0;

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -500,6 +500,28 @@ check('mixed invalid coChangePatterns skips invalid entries without crashing', (
   }
 }));
 
+// Test 22: gsd.workspace_json_max_files config key overrides DEFAULT_MAX_FILES
+check('gsd.workspace_json_max_files config key is respected', () => withTempRepo(dir => {
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.planning', 'config.json'),
+    JSON.stringify({ 'gsd.workspace_json_max_files': 2 })
+  );
+  const fileIndex = {};
+  for (let i = 1; i <= 5; i++) {
+    fileIndex[`src/cfg${i}.ts`] = { fragility: 0.70 + (i * 0.01), aiModificationCount: i, humanModificationCount: 1 };
+  }
+  writeCanonicalWorkspaceJson(dir, { version: '1.0', generated: { version: '1.0', fileIndex } });
+  const result = runHook(dir);
+  let injectedCount = 0;
+  for (let i = 1; i <= 5; i++) {
+    if (result.stdout.includes(`src/cfg${i}.ts`)) injectedCount += 1;
+  }
+  if (injectedCount !== 2) {
+    throw new Error(`Expected 2 files (config override), got ${injectedCount}`);
+  }
+}));
+
 // Report
 let failures = 0;
 for (const [ok, msg] of checks) {

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -81,7 +81,7 @@ check('malformed file does not crash hook', () => withTempRepo(dir => {
 // Test 3: valid canonical-path file injects expected fragile files
 check('canonical-path file injects fragility intelligence', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -105,7 +105,7 @@ check('canonical-path file injects fragility intelligence', () => withTempRepo(d
 // Test 4: legacy-path file is also read
 check('legacy-path file is read when canonical absent', () => withTempRepo(dir => {
   writeLegacyWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -126,7 +126,7 @@ check('legacy-path file is read when canonical absent', () => withTempRepo(dir =
 // Test 5: canonical wins when both present
 check('canonical path wins when both present', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -135,7 +135,7 @@ check('canonical path wins when both present', () => withTempRepo(dir => {
     },
   });
   writeLegacyWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -155,7 +155,7 @@ check('canonical path wins when both present', () => withTempRepo(dir => {
 // Test 6: framework manifest with low confidence is filtered
 check('framework manifest filters low-confidence entries', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       frameworkManifest: [
@@ -176,7 +176,7 @@ check('framework manifest filters low-confidence entries', () => withTempRepo(di
 // Test 7: fragility threshold of 0.7 is enforced (per spec section 3.5)
 check('files below 0.7 fragility threshold are not injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -197,7 +197,7 @@ check('files below 0.7 fragility threshold are not injected', () => withTempRepo
 // Test 8: manual.fragileFiles injection works (spec shape: { path, reason })
 check('manual.fragileFiles are injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     manual: {
       fragileFiles: [
         { path: 'packages/auth/src/index.ts', reason: 'Single point of failure for all authentication. High blast radius.' },
@@ -216,7 +216,7 @@ check('manual.fragileFiles are injected', () => withTempRepo(dir => {
 // Test 9: coChangePatterns are injected (spec shape: { files, note })
 check('coChangePatterns are injected', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     manual: {
       coChangePatterns: [
         {
@@ -250,7 +250,7 @@ check('HANDOFF.json and workspace.json both inject into the same output', () => 
     })
   );
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -278,7 +278,7 @@ check('DEFAULT_MAX_FILES cap is enforced (8 files in, top 5 by fragility out)', 
     };
   }
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: { version: '1.0', fileIndex },
   });
   const result = runHook(dir);
@@ -301,7 +301,7 @@ check('DEFAULT_MAX_FILES cap is enforced (8 files in, top 5 by fragility out)', 
 // Test 12: fragility boundary at exactly 0.7 is included (spec: >= 0.7)
 check('file at exactly 0.7 fragility is included (boundary condition)', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -322,7 +322,7 @@ check('file at exactly 0.7 fragility is included (boundary condition)', () => wi
 // Test 13: mixed manual.fragileFiles — valid entries inject, invalid entries are skipped
 check('mixed manual.fragileFiles skips invalid entries without crashing', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     manual: {
       fragileFiles: [
         { path: 'src/valid.ts', reason: 'Known fragile.' },
@@ -348,7 +348,7 @@ check('mixed manual.fragileFiles skips invalid entries without crashing', () => 
 // Test 14: source 'compact' also triggers injection (supported alongside 'startup')
 check('source compact triggers workspace.json injection', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -365,7 +365,7 @@ check('source compact triggers workspace.json injection', () => withTempRepo(dir
 // Test 15: non-startup/compact source does not inject workspace.json context
 check('source other-than-startup/compact produces no workspace.json injection', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -420,7 +420,7 @@ check('unsupported major version refuses to load', () => withTempRepo(dir => {
 // Test 17b: same major, higher minor version loads successfully (forward-compat within major)
 check('same major different minor version loads successfully', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.5',
+    version: '0.5',
     generated: {
       version: '1.0',
       fileIndex: {
@@ -437,7 +437,7 @@ check('same major different minor version loads successfully', () => withTempRep
 // Test 18: framework confidence boundary at exactly 0.7 is included (>= threshold)
 check('framework at exactly 0.7 confidence is included (boundary condition)', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     generated: {
       version: '1.0',
       frameworkManifest: [
@@ -458,7 +458,7 @@ check('framework at exactly 0.7 confidence is included (boundary condition)', ()
 // Test 19: coChangePatterns without note field renders just file paths (no parenthetical)
 check('coChangePatterns without note renders files only', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     manual: {
       coChangePatterns: [
         { files: ['src/schema.ts', 'src/api.ts'] },
@@ -477,7 +477,7 @@ check('coChangePatterns without note renders files only', () => withTempRepo(dir
 // Test 20: mixed invalid coChangePatterns entries are skipped, valid ones inject
 check('mixed invalid coChangePatterns skips invalid entries without crashing', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
-    version: '1.0',
+    version: '0.1',
     manual: {
       coChangePatterns: [
         { files: ['src/valid-a.ts', 'src/valid-b.ts'], note: 'Must change together.' },
@@ -511,7 +511,7 @@ check('gsd.workspace_json_max_files config key is respected', () => withTempRepo
   for (let i = 1; i <= 5; i++) {
     fileIndex[`src/cfg${i}.ts`] = { fragility: 0.70 + (i * 0.01), aiModificationCount: i, humanModificationCount: 1 };
   }
-  writeCanonicalWorkspaceJson(dir, { version: '1.0', generated: { version: '1.0', fileIndex } });
+  writeCanonicalWorkspaceJson(dir, { version: '0.1', generated: { version: '1.0', fileIndex } });
   const result = runHook(dir);
   let injectedCount = 0;
   for (let i = 1; i <= 5; i++) {

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -256,8 +256,8 @@ check('HANDOFF.json injection still works alongside workspace.json', () => withT
   }
 }));
 
-// Test 11: DEFAULT_MAX_FILES cap enforced — 8 files above threshold, only 5 in output
-check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => withTempRepo(dir => {
+// Test 11: DEFAULT_MAX_FILES cap enforced — 8 files above threshold, only top 5 (by fragility) in output
+check('DEFAULT_MAX_FILES cap is enforced (8 files in, top 5 by fragility out)', () => withTempRepo(dir => {
   const fileIndex = {};
   for (let i = 1; i <= 8; i++) {
     fileIndex[`src/file${i}.ts`] = {
@@ -278,9 +278,37 @@ check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => withTempRep
   if (injectedCount !== 5) {
     throw new Error(`Expected 5 files injected (DEFAULT_MAX_FILES), got ${injectedCount}`);
   }
+  // Top 5 by fragility are file8..file4; file1..file3 must be excluded
+  if (!result.stdout.includes('src/file8.ts')) {
+    throw new Error('Highest-fragility file (file8) not included — sort order wrong');
+  }
+  if (result.stdout.includes('src/file1.ts')) {
+    throw new Error('Lowest-fragility file (file1) should be excluded by cap');
+  }
 }));
 
-// Test 12: mixed manual.fragileFiles — valid entries inject, invalid entries are skipped
+// Test 12: fragility boundary at exactly 0.7 is included (spec: >= 0.7)
+check('file at exactly 0.7 fragility is included (boundary condition)', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/boundary.ts': { fragility: 0.7, aiModificationCount: 3, humanModificationCount: 1 },
+        'src/below.ts': { fragility: 0.699, aiModificationCount: 3, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/boundary.ts')) {
+    throw new Error('File at exactly 0.7 fragility should be included (>= threshold)');
+  }
+  if (result.stdout.includes('src/below.ts')) {
+    throw new Error('File below 0.7 fragility should be excluded');
+  }
+}));
+
+// Test 13: mixed manual.fragileFiles — valid entries inject, invalid entries are skipped
 check('mixed manual.fragileFiles skips invalid entries without crashing', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '1.0',

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -394,8 +394,8 @@ check('array root JSON exits 0 and produces no injection', () => withTempRepo(di
   }
 }));
 
-// Test 17: unsupported version emits stderr warning but still injects data
-check('unsupported version emits warning and still injects', () => withTempRepo(dir => {
+// Test 17: unsupported major version refuses to load with a clear error
+check('unsupported major version refuses to load', () => withTempRepo(dir => {
   writeCanonicalWorkspaceJson(dir, {
     version: '99.0',
     generated: {
@@ -406,11 +406,31 @@ check('unsupported version emits warning and still injects', () => withTempRepo(
     },
   });
   const result = runHook(dir);
-  if (!result.stderr.includes('newer than supported')) {
-    throw new Error('Expected unsupported-version warning in stderr');
+  if (result.status !== 0) {
+    throw new Error(`Hook exited ${result.status} on unsupported major version`);
   }
-  if (!result.stdout.includes('src/future-version.ts')) {
-    throw new Error('Should still inject data for unknown version (best-effort per spec)');
+  if (!result.stderr.includes('Update gsd-plugin or regenerate')) {
+    throw new Error('Expected clear refusal message in stderr');
+  }
+  if (result.stdout.includes('src/future-version.ts')) {
+    throw new Error('Should refuse to inject for unsupported major version');
+  }
+}));
+
+// Test 17b: same major, higher minor version loads successfully (forward-compat within major)
+check('same major different minor version loads successfully', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.5',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/minor-compat.ts': { fragility: 0.82, aiModificationCount: 2, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/minor-compat.ts')) {
+    throw new Error('Same-major different-minor version should load (forward-compat within major)');
   }
 }));
 

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -263,6 +263,60 @@ check('HANDOFF.json injection still works alongside workspace.json', () => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
+// Test 11: DEFAULT_MAX_FILES cap enforced — 8 files above threshold, only 5 in output
+check('DEFAULT_MAX_FILES cap is enforced (8 files in, 5 out)', () => {
+  const dir = makeTempRepo();
+  const fileIndex = {};
+  for (let i = 1; i <= 8; i++) {
+    fileIndex[`src/file${i}.ts`] = {
+      fragility: 0.70 + (i * 0.01),
+      aiModificationCount: i,
+      humanModificationCount: 1,
+    };
+  }
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: { version: '1.0', fileIndex },
+  });
+  const result = runHook(dir);
+  let injectedCount = 0;
+  for (let i = 1; i <= 8; i++) {
+    if (result.stdout.includes(`src/file${i}.ts`)) injectedCount += 1;
+  }
+  if (injectedCount !== 5) {
+    throw new Error(`Expected 5 files injected (DEFAULT_MAX_FILES), got ${injectedCount}`);
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 12: mixed manual.fragileFiles — valid entries inject, invalid entries are skipped
+check('mixed manual.fragileFiles skips invalid entries without crashing', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    manual: {
+      fragileFiles: [
+        { path: 'src/valid.ts', reason: 'Known fragile.' },
+        'bare string entry',
+        null,
+        { path: 'src/missing-reason.ts' },
+        { reason: 'missing path' },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (result.status !== 0) {
+    throw new Error(`Hook exited ${result.status} on mixed fragileFiles array`);
+  }
+  if (!result.stdout.includes('src/valid.ts')) {
+    throw new Error('Valid fragileFiles entry was not injected');
+  }
+  if (result.stdout.includes('bare string entry') || result.stdout.includes('missing-reason') || result.stdout.includes('missing path')) {
+    throw new Error('Invalid fragileFiles entry leaked into output');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
 // Report
 let failures = 0;
 for (const [ok, msg] of checks) {

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -40,12 +40,12 @@ function writeLegacyWorkspaceJson(dir, content) {
   );
 }
 
-function runHook(cwd) {
+function runHook(cwd, source) {
   const result = spawnSync('node', [HOOK_BIN, 'hook', 'session-start'], {
     cwd,
     encoding: 'utf-8',
     timeout: 5000,
-    input: JSON.stringify({ source: 'startup' }),
+    input: JSON.stringify({ source: source || 'startup' }),
   });
   return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
 }
@@ -235,8 +235,8 @@ check('coChangePatterns are injected', () => withTempRepo(dir => {
   }
 }));
 
-// Test 10: HANDOFF.json read is unaffected by workspace.json presence
-check('HANDOFF.json injection still works alongside workspace.json', () => withTempRepo(dir => {
+// Test 10: HANDOFF.json and workspace.json coexist — both appear in the same output
+check('HANDOFF.json and workspace.json both inject into the same output', () => withTempRepo(dir => {
   fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
   fs.writeFileSync(
     path.join(dir, '.planning', 'HANDOFF.json'),
@@ -249,10 +249,21 @@ check('HANDOFF.json injection still works alongside workspace.json', () => withT
       partial: false,
     })
   );
-  writeCanonicalWorkspaceJson(dir, { version: '1.0', generated: { version: '1.0' } });
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/coexist.ts': { fragility: 0.88, aiModificationCount: 4, humanModificationCount: 1 },
+      },
+    },
+  });
   const result = runHook(dir);
   if (!result.stdout.includes('Phase 4')) {
     throw new Error('HANDOFF.json injection regressed');
+  }
+  if (!result.stdout.includes('src/coexist.ts')) {
+    throw new Error('workspace.json injection missing when HANDOFF also present');
   }
 }));
 
@@ -331,6 +342,141 @@ check('mixed manual.fragileFiles skips invalid entries without crashing', () => 
   }
   if (result.stdout.includes('bare string entry') || result.stdout.includes('missing-reason') || result.stdout.includes('missing path')) {
     throw new Error('Invalid fragileFiles entry leaked into output');
+  }
+}));
+
+// Test 14: source 'compact' also triggers injection (supported alongside 'startup')
+check('source compact triggers workspace.json injection', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/compact-test.ts': { fragility: 0.82, aiModificationCount: 3, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir, 'compact');
+  if (!result.stdout.includes('src/compact-test.ts')) {
+    throw new Error('source=compact did not trigger workspace.json injection');
+  }
+}));
+
+// Test 15: non-startup/compact source does not inject workspace.json context
+check('source other-than-startup/compact produces no workspace.json injection', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/should-not-appear.ts': { fragility: 0.9, aiModificationCount: 5, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir, 'post-tool');
+  if (result.stdout.includes('src/should-not-appear.ts')) {
+    throw new Error('Workspace injection fired for unsupported source type');
+  }
+}));
+
+// Test 16: non-object root JSON (array) exits 0 and produces no injection
+check('array root JSON exits 0 and produces no injection', () => withTempRepo(dir => {
+  fs.writeFileSync(path.join(dir, '.agents', 'agents.workspace.json'), '[1, 2, 3]');
+  const result = runHook(dir);
+  if (result.status !== 0) {
+    throw new Error(`Hook exited ${result.status} on array root JSON`);
+  }
+  if (result.stdout.includes('workspace.json')) {
+    throw new Error('Array root JSON should produce no workspace context');
+  }
+  if (!result.stderr.includes('not a JSON object')) {
+    throw new Error('Expected "not a JSON object" diagnostic in stderr');
+  }
+}));
+
+// Test 17: unsupported version emits stderr warning but still injects data
+check('unsupported version emits warning and still injects', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '99.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/future-version.ts': { fragility: 0.85, aiModificationCount: 3, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stderr.includes('newer than supported')) {
+    throw new Error('Expected unsupported-version warning in stderr');
+  }
+  if (!result.stdout.includes('src/future-version.ts')) {
+    throw new Error('Should still inject data for unknown version (best-effort per spec)');
+  }
+}));
+
+// Test 18: framework confidence boundary at exactly 0.7 is included (>= threshold)
+check('framework at exactly 0.7 confidence is included (boundary condition)', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      frameworkManifest: [
+        { name: 'react', version: '18.0', confidence: 0.7 },
+        { name: 'too-uncertain', version: '1.0', confidence: 0.699 },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('react@18.0')) {
+    throw new Error('Framework at exactly 0.7 confidence should be included (>= threshold)');
+  }
+  if (result.stdout.includes('too-uncertain')) {
+    throw new Error('Framework below 0.7 confidence should be excluded');
+  }
+}));
+
+// Test 19: coChangePatterns without note field renders just file paths (no parenthetical)
+check('coChangePatterns without note renders files only', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    manual: {
+      coChangePatterns: [
+        { files: ['src/schema.ts', 'src/api.ts'] },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/schema.ts')) {
+    throw new Error('coChangePattern without note should still inject file paths');
+  }
+  if (result.stdout.includes('undefined') || result.stdout.includes('null')) {
+    throw new Error('Missing note field produced garbage in output');
+  }
+}));
+
+// Test 20: mixed invalid coChangePatterns entries are skipped, valid ones inject
+check('mixed invalid coChangePatterns skips invalid entries without crashing', () => withTempRepo(dir => {
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    manual: {
+      coChangePatterns: [
+        { files: ['src/valid-a.ts', 'src/valid-b.ts'], note: 'Must change together.' },
+        null,
+        'bare string',
+        { files: [] },
+        { note: 'no files array' },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (result.status !== 0) {
+    throw new Error(`Hook exited ${result.status} on mixed coChangePatterns`);
+  }
+  if (!result.stdout.includes('src/valid-a.ts')) {
+    throw new Error('Valid coChangePattern was not injected');
+  }
+  if (result.stdout.includes('bare string') || result.stdout.includes('no files array')) {
+    throw new Error('Invalid coChangePattern entry leaked into output');
   }
 }));
 

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -1,0 +1,279 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const HOOK_BIN = path.join(__dirname, '..', 'bin', 'gsd-tools.cjs');
+
+function makeTempRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-workspace-test-'));
+  fs.mkdirSync(path.join(dir, '.agents'), { recursive: true });
+  return dir;
+}
+
+function writeCanonicalWorkspaceJson(dir, content) {
+  fs.writeFileSync(
+    path.join(dir, '.agents', 'agents.workspace.json'),
+    JSON.stringify(content, null, 2)
+  );
+}
+
+function writeLegacyWorkspaceJson(dir, content) {
+  fs.writeFileSync(
+    path.join(dir, 'agents.workspace.json'),
+    JSON.stringify(content, null, 2)
+  );
+}
+
+function runHook(cwd) {
+  const result = spawnSync('node', [HOOK_BIN, 'hook', 'session-start'], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 5000,
+    input: JSON.stringify({ source: 'startup' }),
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+const checks = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    checks.push([true, name]);
+  } catch (err) {
+    checks.push([false, `${name}: ${err.message}`]);
+  }
+}
+
+// Test 1: absent file produces zero workspace.json output
+check('absent file produces no workspace.json injection', () => {
+  const dir = makeTempRepo();
+  const result = runHook(dir);
+  if (result.stdout.includes('workspace.json')) {
+    throw new Error('Hook injected workspace.json context when file was absent');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 2: malformed file fails soft
+check('malformed file does not crash hook', () => {
+  const dir = makeTempRepo();
+  fs.writeFileSync(path.join(dir, '.agents', 'agents.workspace.json'), '{not valid json');
+  const result = runHook(dir);
+  if (result.status !== 0) {
+    throw new Error(`Hook exited with status ${result.status} on malformed file`);
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 3: valid canonical-path file injects expected fragile files
+check('canonical-path file injects fragility intelligence', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/auth/middleware.ts': {
+          fragility: 0.91,
+          aiModificationCount: 8,
+          humanModificationCount: 2,
+        },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/auth/middleware.ts')) {
+    throw new Error('Hook did not inject fragile file path');
+  }
+  if (!result.stdout.includes('0.91')) {
+    throw new Error('Hook did not inject fragility score');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 4: legacy-path file is also read
+check('legacy-path file is read when canonical absent', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-workspace-legacy-'));
+  writeLegacyWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/legacy.ts': {
+          fragility: 0.85,
+          aiModificationCount: 5,
+          humanModificationCount: 1,
+        },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/legacy.ts')) {
+    throw new Error('Legacy-path workspace.json was not read');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 5: canonical wins when both present
+check('canonical path wins when both present', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/canonical.ts': { fragility: 0.91, aiModificationCount: 5, humanModificationCount: 1 },
+      },
+    },
+  });
+  writeLegacyWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/legacy.ts': { fragility: 0.91, aiModificationCount: 5, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/canonical.ts')) {
+    throw new Error('Canonical path file was not preferred');
+  }
+  if (result.stdout.includes('src/legacy.ts')) {
+    throw new Error('Legacy file should not be read when canonical exists');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 6: framework manifest with low confidence is filtered
+check('framework manifest filters low-confidence entries', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      frameworkManifest: [
+        { name: 'next', version: '14.2', confidence: 0.99 },
+        { name: 'unknown-framework', version: '?', confidence: 0.3 },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('next@14.2')) {
+    throw new Error('High-confidence framework not injected');
+  }
+  if (result.stdout.includes('unknown-framework')) {
+    throw new Error('Low-confidence framework should have been filtered');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 7: fragility threshold of 0.7 is enforced (per spec section 3.5)
+check('files below 0.7 fragility threshold are not injected', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/high.ts': { fragility: 0.85, aiModificationCount: 5, humanModificationCount: 1 },
+        'src/low.ts': { fragility: 0.5, aiModificationCount: 2, humanModificationCount: 1 },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/high.ts')) {
+    throw new Error('Above-threshold file was not injected');
+  }
+  if (result.stdout.includes('src/low.ts')) {
+    throw new Error('Below-threshold file should have been filtered per spec section 3.5');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 8: manual.fragileFiles injection works (spec shape: { path, reason })
+check('manual.fragileFiles are injected', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    manual: {
+      fragileFiles: [
+        { path: 'packages/auth/src/index.ts', reason: 'Single point of failure for all authentication. High blast radius.' },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('packages/auth/src/index.ts')) {
+    throw new Error('Manual fragile file path not injected');
+  }
+  if (!result.stdout.includes('Single point of failure')) {
+    throw new Error('Manual fragile file reason not injected');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 9: coChangePatterns are injected (spec shape: { files, note })
+check('coChangePatterns are injected', () => {
+  const dir = makeTempRepo();
+  writeCanonicalWorkspaceJson(dir, {
+    version: '1.0',
+    manual: {
+      coChangePatterns: [
+        {
+          files: ['packages/contracts/src/user.ts', 'apps/api/src/routes/users.ts'],
+          note: 'Schema changes require simultaneous API route updates.',
+        },
+      ],
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('packages/contracts/src/user.ts')) {
+    throw new Error('coChangePattern files not injected');
+  }
+  if (!result.stdout.includes('Schema changes')) {
+    throw new Error('coChangePattern note not injected');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Test 10: HANDOFF.json read is unaffected by workspace.json presence
+check('HANDOFF.json injection still works alongside workspace.json', () => {
+  const dir = makeTempRepo();
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.planning', 'HANDOFF.json'),
+    JSON.stringify({
+      version: '1.0',
+      phase_name: 'Phase 4',
+      plan: '01',
+      task: 3,
+      source: 'manual-pause',
+      partial: false,
+    })
+  );
+  writeCanonicalWorkspaceJson(dir, { version: '1.0', generated: { version: '1.0' } });
+  const result = runHook(dir);
+  if (!result.stdout.includes('Phase 4')) {
+    throw new Error('HANDOFF.json injection regressed');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Report
+let failures = 0;
+for (const [ok, msg] of checks) {
+  console.log(ok ? `  ok  ${msg}` : `  FAIL  ${msg}`);
+  if (!ok) failures += 1;
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} of ${checks.length} checks failed`);
+  process.exit(1);
+}
+
+console.log(`\nAll ${checks.length} checks passed`);
+process.exit(0);


### PR DESCRIPTION
## What

Adds optional \`agents.workspace.json\` integration to the SessionStart hook.

When the file is present at \`.agents/agents.workspace.json\` (or the legacy
location at repo root), the hook reads it and injects the relevant slices
as session context:

- Fragility scores, AI/human modification counts (\`generated.fileIndex\`)
- Detected framework stack (\`generated.frameworkManifest\`)
- \`manual.fragileFiles\`
- \`manual.coChangePatterns\`

When the file is absent, the hook behaves identically to today. Zero token impact.

## Why

Per the discussion in #5: workspace.json is an open spec for structured
codebase intelligence, designed as a complement to AGENTS.md and PROJECT.md.
It surfaces empirical signals that human-authored convention files cannot
capture — fragility scores, AI regression history, co-change relationships.

## Scope

Per the agreement in #5, this PR is intentionally narrow:

- The \`generated\` section is read in full (no overlap with PROJECT.md)
- \`manual.fragileFiles\` and \`manual.coChangePatterns\` are read (no overlap
  with PROJECT.md)
- Other \`manual.*\` fields are not read. PROJECT.md remains the source of
  truth for human-authored conventions.

## Version compatibility

Same major, any minor: load without warning (e.g. a \`0.5\` file loads fine against a plugin that knows \`0.1\`).
Different major: refuse to load with a clear stderr message naming the file version and the supported range.

\`SUPPORTED_VERSIONS\` ships as \`['0.1']\` only. \`1.0\` is not pre-blessed — the spec
hasn't published that version yet, and it may carry non-additive changes from the \`0.x\`
line. \`1.0\` will be added once it ships and is verified compatible.

## How the empirical signal gets populated

Two tiers, both zero-cost to users who don't adopt workspace.json:

**Tier 1 — agents-audit CLI (no daemon, no hooks):**
\`npx agents-audit scan .\` performs a one-shot static git history analysis.
\`aiModificationCount\` and \`humanModificationCount\` are approximated from commit
attribution heuristics (commit message patterns, co-author tags, tool signatures).
Useful and directionally correct; not real-time. No pre-commit hook is registered
unconditionally — the CLI only runs when explicitly invoked.

**Tier 2 — Vreko daemon (live behavioral observation):**
The daemon observes filesystem events and attributes them to the tool that triggered
the write. Counts become genuinely empirical as sessions accumulate. The daemon only
writes workspace.json for repos where the user has explicitly initialized it.

Zero-cost convention holds through both populate paths.

## Spec compliance

The 0.7 fragility threshold is per spec section 3.5 (Health Signals), which
defines fragile files as those with fragility >= 0.7.

Path search order is canonical first (\`.agents/agents.workspace.json\`), then
legacy fallback (\`agents.workspace.json\` at repo root), per spec section 2.

## Files changed

- \`bin/lib/workspace-json.cjs\` (new) — reader + context builder
- \`bin/gsd-tools.cjs\` — SessionStart addition (~22 lines)
- \`tests/workspace-json-integration.test.cjs\` (new, 22 checks)

## Configuration

Optional config key \`gsd.workspace_json_max_files\` in \`.planning/config.json\`
controls the maximum number of fragile files surfaced in injected context. Default 5.

## Testing

```bash
node tests/workspace-json-integration.test.cjs
```

22 checks covering: absent file, malformed JSON, non-object root JSON, canonical path,
legacy path, canonical-wins precedence, framework confidence filtering (including
boundary at 0.7), fragility threshold enforcement (including boundary at 0.7),
manual.fragileFiles, mixed invalid fragileFiles resilience, coChangePatterns (with and
without note field), mixed invalid coChangePatterns resilience, HANDOFF.json coexistence,
DEFAULT_MAX_FILES cap with sort-order verification, source=compact trigger,
source=other suppression, unsupported major version refusal,
same-major/different-minor forward-compatibility, and \`gsd.workspace_json_max_files\`
config override.

## Spec reference

- Spec: https://workspacejson.dev/spec
- JSON Schema: https://workspacejson.dev/schema/v1.json

Closes #5