### PR TITLE
fix(session-start): skip resume prompt for trivial auto-compact checkpoints

### DIFF
--- a/bin/gsd-tools.cjs
+++ b/bin/gsd-tools.cjs
@@ -1211,19 +1211,23 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
             const handoffPath = path.join(planningPaths(cwd).planning, 'HANDOFF.json');
             if (fs.existsSync(handoffPath)) {
               const handoff = JSON.parse(fs.readFileSync(handoffPath, 'utf-8'));
-              const phase = handoff.phase_name || handoff.phase || 'unknown';
-              const plan = handoff.plan || '?';
-              const task = handoff.task || '?';
-              const handoffSource = handoff.source || 'unknown';
+              // Skip trivial auto-compact checkpoints with no in-progress work
+              const hasMeaningfulWork = handoff.phase !== null || handoff.task !== null;
+              if (hasMeaningfulWork) {
+                const phase = handoff.phase_name || handoff.phase || 'unknown';
+                const plan = handoff.plan || '?';
+                const task = handoff.task || '?';
+                const handoffSource = handoff.source || 'unknown';
 
-              const systemMsg = [
-                'GSD session continuity: Found checkpoint from previous session.',
-                `Phase: ${phase}, Plan: ${plan}, Task: ${task} (source: ${handoffSource}).`,
-                'Run /gsd:resume-work to restore context and continue.',
-                'Do this immediately without waiting for user input.'
-              ].join(' ');
-              process.stdout.write(systemMsg);
-              process.stderr.write('GSD: session checkpoint detected, auto-resuming...\n');
+                const systemMsg = [
+                  'GSD session continuity: Found checkpoint from previous session.',
+                  `Phase: ${phase}, Plan: ${plan}, Task: ${task} (source: ${handoffSource}).`,
+                  'Run /gsd:resume-work to restore context and continue.',
+                  'Do this immediately without waiting for user input.'
+                ].join(' ');
+                process.stdout.write(systemMsg);
+                process.stderr.write('GSD: session checkpoint detected, auto-resuming...\n');
+              }
             }
           } catch { /* never break session start */ }
         }


### PR DESCRIPTION
## Problem

When a session ends with no active phase or task, the pre-compact hook writes a `HANDOFF.json` with `null` phase and task fields. On the next session start, this triggers a `/gsd:resume-work` system message — including the expensive "Do this immediately without waiting for user input" directive — even though there's nothing to resume.

This wastes tokens on the resume skill invocation and adds noise at the start of every session after an auto-compact.

## Fix

Add a guard in the `session-start` hook: only emit the resume system message when `handoff.phase !== null || handoff.task !== null`. Trivial auto-compact checkpoints (clean-slate sessions) are silently ignored.

```js
const hasMeaningfulWork = handoff.phase !== null || handoff.task !== null;
if (hasMeaningfulWork) {
  // emit resume prompt
}
```

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Session ends mid-task (phase + task set) | Resume prompt fires ✓ | Resume prompt fires ✓ |
| Session ends clean (no active work) | Resume prompt fires ✗ | Silent ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)