### PR TITLE
fix: extend workspace.json lookup to three-slot fallback chain (v0.4 compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ History before 2.38.2 lives in git + the per-milestone archive (see `.planning/m
 
 ## [Unreleased]
 
+### Fixed
+- Canonical `workspace.json` path corrected from `.agents/agents.workspace.json` to `.agents/workspace.json` ([#10](https://github.com/jnuyens/gsd-plugin/issues/10#issuecomment-4574148528)). Both legacy paths are preserved for backwards compatibility: the prior `.agents/agents.workspace.json` location and the repo-root `agents.workspace.json` fallback.
+
 ## [2.45.9] - 2026-05-29  (based on upstream GSD 1.42.3, hosted at open-gsd/get-shit-done-redux)
 
 Behavior change addressing a real felt issue: in larger projects, GSD-managed milestones tend toward unbounded growth because the architecture has 4 workflows that add phases (`add-phase`, `insert-phase`, `add-backlog`, `plan-milestone-gaps`) against 1 that effectively closes them (`complete-milestone`). When `gsd-verifier` returns `gaps_found`, the historical default was to route the gaps into a follow-up phase via `/gsd:plan-phase --gaps`. That kept gap-driven phase multiplication going indefinitely.

--- a/bin/lib/workspace-json.cjs
+++ b/bin/lib/workspace-json.cjs
@@ -3,8 +3,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const CANONICAL_PATH = ['.agents', 'agents.workspace.json'];
-const LEGACY_PATH = ['agents.workspace.json'];
+const CANONICAL_PATH     = ['.agents', 'workspace.json'];
+const LEGACY_AGENTS_PATH = ['.agents', 'agents.workspace.json'];
+const LEGACY_PATH        = ['agents.workspace.json'];
 
 const FRAGILITY_THRESHOLD = 0.7;
 const FRAMEWORK_CONFIDENCE_THRESHOLD = 0.7;
@@ -21,7 +22,7 @@ const MAX_CO_CHANGE_PATTERNS = 200;
 
 // Returns null if absent, malformed, or unreadable — never throws.
 function readWorkspaceJson(cwd) {
-  for (const segments of [CANONICAL_PATH, LEGACY_PATH]) {
+  for (const segments of [CANONICAL_PATH, LEGACY_AGENTS_PATH, LEGACY_PATH]) {
     const filePath = path.join(cwd, ...segments);
     let raw;
     try {
@@ -169,6 +170,7 @@ module.exports = {
   readWorkspaceJson,
   buildContextString,
   CANONICAL_PATH,
+  LEGACY_AGENTS_PATH,
   LEGACY_PATH,
   FRAGILITY_THRESHOLD,
   DEFAULT_MAX_FILES,

--- a/tests/workspace-json-integration.test.cjs
+++ b/tests/workspace-json-integration.test.cjs
@@ -28,6 +28,13 @@ function withTempRepo(fn, opts) {
 
 function writeCanonicalWorkspaceJson(dir, content) {
   fs.writeFileSync(
+    path.join(dir, '.agents', 'workspace.json'),
+    JSON.stringify(content, null, 2)
+  );
+}
+
+function writeLegacyAgentsWorkspaceJson(dir, content) {
+  fs.writeFileSync(
     path.join(dir, '.agents', 'agents.workspace.json'),
     JSON.stringify(content, null, 2)
   );
@@ -71,7 +78,7 @@ check('absent file produces no workspace.json injection', () => withTempRepo(dir
 
 // Test 2: malformed file fails soft
 check('malformed file does not crash hook', () => withTempRepo(dir => {
-  fs.writeFileSync(path.join(dir, '.agents', 'agents.workspace.json'), '{not valid json');
+  fs.writeFileSync(path.join(dir, '.agents', 'workspace.json'), '{not valid json');
   const result = runHook(dir);
   if (result.status !== 0) {
     throw new Error(`Hook exited with status ${result.status} on malformed file`);
@@ -381,7 +388,7 @@ check('source other-than-startup/compact produces no workspace.json injection', 
 
 // Test 16: non-object root JSON (array) exits 0 and produces no injection
 check('array root JSON exits 0 and produces no injection', () => withTempRepo(dir => {
-  fs.writeFileSync(path.join(dir, '.agents', 'agents.workspace.json'), '[1, 2, 3]');
+  fs.writeFileSync(path.join(dir, '.agents', 'workspace.json'), '[1, 2, 3]');
   const result = runHook(dir);
   if (result.status !== 0) {
     throw new Error(`Hook exited ${result.status} on array root JSON`);
@@ -497,6 +504,33 @@ check('mixed invalid coChangePatterns skips invalid entries without crashing', (
   }
   if (result.stdout.includes('bare string') || result.stdout.includes('no files array')) {
     throw new Error('Invalid coChangePattern entry leaked into output');
+  }
+}));
+
+// Test 21: legacy path (.agents/agents.workspace.json) is still fully consumed
+check('legacy agents path (.agents/agents.workspace.json) is read and fully consumed', () => withTempRepo(dir => {
+  writeLegacyAgentsWorkspaceJson(dir, {
+    version: '0.1',
+    generated: {
+      version: '1.0',
+      fileIndex: {
+        'src/legacy-agents-path.ts': {
+          fragility: 0.88,
+          aiModificationCount: 6,
+          humanModificationCount: 2,
+        },
+      },
+    },
+  });
+  const result = runHook(dir);
+  if (!result.stdout.includes('src/legacy-agents-path.ts')) {
+    throw new Error('Legacy agents path file was not read');
+  }
+  if (!result.stdout.includes('0.88')) {
+    throw new Error('Legacy agents path: fragility score not consumed — file found but content was not fully parsed');
+  }
+  if (!result.stdout.includes('6 AI')) {
+    throw new Error('Legacy agents path: aiModificationCount not consumed — partial read suspected');
   }
 }));
 


### PR DESCRIPTION
## What this does

Adds the v0.4 canonical path (`.agents/workspace.json`) to gsd-plugin's reader fallback chain, ahead of the existing paths rather than replacing them. Refs #10.

The canonical filename inside `.agents/` moved as part of workspace.json v0.4. This keeps gsd-plugin reading every file shape in the wild, preferring the new path when present and falling back to the v0.3 path for users who already have `.agents/agents.workspace.json` on disk. Purely additive to your fallback chain, no breaking changes.

## The change

`bin/lib/workspace-json.cjs` — the reader loop goes from two slots to three:

\`\`\`
1. .agents/workspace.json          (v0.4, preferred)
2. .agents/agents.workspace.json   (v0.3, compat — new slot)
3. agents.workspace.json           (repo-root, pre-existing legacy)
\`\`\`

`CANONICAL_PATH` keeps its meaning (preferred path), `LEGACY_PATH` still points at the repo-root file, and `LEGACY_AGENTS_PATH` slots in between. Existing reads of the path constants are unaffected; the new constant is exported alongside them.

## Why a PR instead of just flagging it

The path change happened on our branding track and you weren't looped into it, so I'd rather hand you the fix than hand you a to-do. You took the first bet on this spec back in #6, and the zero-breaking-changes promise from the v0.4 coordination should hold on the path axis too, not just the schema. Merge whenever suits you.

Happy to adjust the approach if you'd rather handle the fallback differently — your repo, your call on the shape.

## Tests

Added Test 21, which writes a fixture to the v0.3 path (`.agents/agents.workspace.json`) and asserts the reader returns the parsed object with correct fragility score and aiModificationCount, proving full consumption through slot 2, not just presence. CHANGELOG updated under `[Unreleased]`.