### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #22)

### DIFF
--- a/skills/add-todo/SKILL.md
+++ b/skills/add-todo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:add-todo
 description: Capture idea or task as todo from current conversation context
-argument-hint: [optional description]
+argument-hint: "[optional description]"
 allowed-tools:
   - Read
   - Write

--- a/skills/check-todos/SKILL.md
+++ b/skills/check-todos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:check-todos
 description: List pending todos and select one to work on
-argument-hint: [area filter]
+argument-hint: "[area filter]"
 allowed-tools:
   - Read
   - Write

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [list | status <slug> | continue <slug> | --diagnose] [issue description]
+argument-hint: "[list | status <slug> | continue <slug> | --diagnose] [issue description]"
 allowed-tools:
   - Read
   - Bash

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:health
 description: Diagnose planning directory health and optionally repair issues
-argument-hint: [--repair]
+argument-hint: "[--repair]"
 allowed-tools:
   - Read
   - Bash


### PR DESCRIPTION
Closes #22.

## Summary

Purely mechanical single-character transform to 4 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (4)

- `skills/health/SKILL.md`
- `skills/add-todo/SKILL.md`
- `skills/check-todos/SKILL.md`
- `skills/debug/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
